### PR TITLE
hw - fix typo in MenuItem Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -43,7 +43,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
     public UCSBDiningCommonsMenuItem getUCSBDiningCommonsMenuItem(
-            @Parameter(name="code") @RequestParam Long id) {
+            @Parameter(name="id") @RequestParam Long id) {
         UCSBDiningCommonsMenuItem MenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
 


### PR DESCRIPTION
In this pull request, I fixed a typo in MenuItem Controller (changing "code" to "id")